### PR TITLE
Standardize publication to GitHub for public + private packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A minor re-write of [albertorestifo/node-dijkstra](https://github.com/albertores
 ## Installation
 
 ```shell
-yarn add smart-parks/dijkstra
+yarn add @smart-parks/dijkstra
 ```
 
 ## Usage
@@ -114,3 +114,10 @@ If `options.cost` is `false` (default behaviour) an `Array` will be returned, co
 If `options.cost` is `true`, an `Object` with keys `path` and `cost` will be returned. `path` follows the same rules as above and `cost` is the total cost of the found route between nodes.
 
 When to route can be found, the path will be set to `null`.
+
+## Publishing to NPM
+
+```shell
+npm login --registry=https://npm.pkg.github.com/ # Generate and use a well-scoped GitHub personal access token as the password.
+npm publish
+```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dijkstra",
+  "name": "@smart-parks/dijkstra",
   "version": "2.5.0",
   "description": "An implementation of Dijkstra's algorithm",
   "contributors": [
@@ -17,6 +17,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/smart-parks/dijkstra"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
   },
   "scripts": {
     "build": "rollup -c rollup.config.js; du index.js; gzip -c index.js | wc -c",


### PR DESCRIPTION
@nhunzaker since this repo is public, the associated packages are public. The publication steps will be the same once we have a private package, we'll just need to add some config to a yarnrc file for the projects that consume those.